### PR TITLE
[Bug fix] The Japanese locale is not applied to the app server module deployed to Cloud Run.

### DIFF
--- a/.github/workflows/deploy_cloud_run.yml
+++ b/.github/workflows/deploy_cloud_run.yml
@@ -65,6 +65,9 @@ jobs:
           tags: |
             ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ github.sha }}
             ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:latest
+          build-args: |
+            PROJECT_NUMBER=${{ env.PROJECT_NUMBER }}
+            APP_LOCALE_LANGUAGE=${{ env.APP_LOCALE }}
           secrets: |
             "github_credentials=export GITHUB_USER=${{ github.actor }}
             export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"

--- a/.run/LineScheduleNotifier App.run.xml
+++ b/.run/LineScheduleNotifier App.run.xml
@@ -2,6 +2,7 @@
   <configuration default="false" name="LineScheduleNotifier App" type="KtorApplicationConfigurationType" factoryName="Ktor">
     <envs>
       <env name="PROJECT_NUMBER" value="111111111111" />
+      <env name="APP_LOCALE_LANGUAGE" value="ja" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="io.ktor.server.netty.EngineMain" />
     <module name="LineScheduleNotifier.main" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ WORKDIR /app
 ARG PROJECT_NUMBER=111111111111
 ENV PROJECT_NUMBER=${PROJECT_NUMBER}
 
+# Define the application locale with a default for local development
+ARG APP_LOCALE_LANGUAGE=en
+ENV APP_LOCALE_LANGUAGE=${APP_LOCALE_LANGUAGE}
+
 # Copy only the built JAR file from the build stage
 # Note: Ensure the JAR filename pattern matches your build/libs output
 COPY --from=build /app/build/libs/LineScheduleNotifier-*-all.jar /app/app.jar

--- a/README.md
+++ b/README.md
@@ -45,6 +45,44 @@ To build the project and create the necessary artifacts, run:
 ./gradlew build
 ```
 
+## Running with Docker (Local)
+
+To verify the Docker image and run the application in a containerized environment locally, use Docker Compose.
+This setup mounts the local `src/main/resources` directory, allowing the container to use `application-local.yaml` for local-specific configurations.
+
+### Authentication for GitHub Packages
+
+This project depends on libraries hosted on GitHub Packages. To build the Docker image locally, you must provide your GitHub credentials so that Gradle can download these dependencies.
+
+1.  **Create a Personal Access Token (PAT)** on GitHub with the `read:packages` scope.
+2.  In the root of the project, create a file named `github-credentials.txt`.
+3.  Add the following content to the file, replacing the placeholders with your actual username and the PAT you just created:
+
+    ```
+    export GITHUB_USER=<Your GitHub Username>
+    export GITHUB_TOKEN=<Your GitHub Personal Access Token>
+    ```
+
+This file is used by `docker-compose.yml` to securely pass the credentials to the Docker build process. It is listed in `.gitignore` and should not be committed to version control.
+
+### Starting the Container
+
+To build the image and start the container, provide the `PROJECT_NUMBER` and optionally the `APP_LOCALE_LANGUAGE` as environment variables.
+
+For example, to run the application in Japanese:
+```shell
+PROJECT_NUMBER=111111111111 APP_LOCALE_LANGUAGE=ja docker compose up --build
+```
+Supported locales are `en` (English) and `ja` (Japanese). If `APP_LOCALE_LANGUAGE` is not specified, it defaults to `en`.
+
+### Stopping the Container
+
+To stop the container and remove the created resources:
+
+```shell
+docker compose down
+```
+
 ## API Endpoint
 
 ### `POST /webhook`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       dockerfile: Dockerfile
       args:
         - PROJECT_NUMBER=${PROJECT_NUMBER:-111111111111}
+        - APP_LOCALE_LANGUAGE=${APP_LOCALE_LANGUAGE:-en}
       secrets:
         - github_credentials
 
@@ -45,6 +46,7 @@ services:
     # Use mapping style for environment variables.
     environment:
       PROJECT_NUMBER: ${PROJECT_NUMBER:-111111111111}
+      APP_LOCALE_LANGUAGE: ${APP_LOCALE_LANGUAGE:-en}
       GOOGLE_APPLICATION_CREDENTIALS: /app/gcp-credentials.json
 
     # Override the default CMD to pass configuration arguments.

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -15,8 +15,6 @@
 #
 
 app:
-  locale:
-    language: "ja"
   provider:
     secret_manager: "mock"
     google_workspace: "mock"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,7 @@ ktor:
 app:
   name: "LineScheduleNotifier"
   locale:
-    language: "en"
+    language: ${APP_LOCALE_LANGUAGE:-en}
   provider:
     secret_manager: "cloud"
     google_workspace: "cloud"


### PR DESCRIPTION
### Pre-merge Checklist

- [x] Assignees are set.
- [x] Labels are set.
- [x] Milestone is set.

---

## Related issues

* #10

### Cause of bug

* The application's locale was hardcoded to "en" in application.yaml.
* The APP_LOCALE_LANGUAGE environment variable, intended to override this, was not being correctly applied because Ktor's automatic environment-to-configuration mapping was not functioning as expected in the project's setup.

### What's fixed

* Modified application.yaml to explicitly read the locale from the APP_LOCALE_LANGUAGE environment variable, with "en" as a fallback. This ensures the locale can be reliably configured via the environment.
* Updated Dockerfile, docker-compose.yml, and the GitHub Actions workflow (deploy_cloud_run.yml) to properly build and run the container with the specified locale.
* Updated README.md with detailed instructions on how to run the application locally using Docker, including an explanation of the required environment variables (PROJECT_NUMBER, APP_LOCALE_LANGUAGE) and the credentials needed for GitHub Packages.

### Unit Test

* Confirmed that the locale setting works correctly for local execution in both IntelliJ and a containerized environment using docker compose.
* Verified that setting APP_LOCALE_LANGUAGE=ja results in the application serving content in Japanese.
* Confirmed that the application correctly defaults to English (en) when the environment variable is not set.

### Notes

* 
