### PR TITLE
[Bug fix] The dates and times on Cloud Run are based on UTC rather than JST.

### DIFF
--- a/src/main/kotlin/org/fog_rock/lineschedulenotifier/domain/provider/WeeklyScheduleProvider.kt
+++ b/src/main/kotlin/org/fog_rock/lineschedulenotifier/domain/provider/WeeklyScheduleProvider.kt
@@ -23,6 +23,7 @@ import org.fog_rock.lineschedulenotifier.extension.isBetween
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
@@ -54,7 +55,7 @@ class WeeklyScheduleProvider(
      * @return A formatted message string, or null if no schedule is available.
      */
     fun provideMessage(): String? {
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Tokyo"))
         val startDate = today.plusDays(1)
         val endDate = today.plusWeeks(1)
 

--- a/src/test/kotlin/org/fog_rock/lineschedulenotifier/domain/provider/WeeklyScheduleProviderTest.kt
+++ b/src/test/kotlin/org/fog_rock/lineschedulenotifier/domain/provider/WeeklyScheduleProviderTest.kt
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.ZoneId
 
 class WeeklyScheduleProviderTest {
 
@@ -47,7 +48,7 @@ class WeeklyScheduleProviderTest {
     fun setup() {
         // Mock LocalDate.now()
         mockkStatic(LocalDate::class)
-        every { LocalDate.now() } returns today
+        every { LocalDate.now(ZoneId.of("Asia/Tokyo")) } returns today
 
         scheduleDataSource = mockk()
         messageProvider = mockk(relaxed = true) {
@@ -119,7 +120,7 @@ class WeeklyScheduleProviderTest {
                 "May Item"
             )
         )
-        every { LocalDate.now() } returns aprilDate.minusDays(2) // Set today to 2026-04-28 to cross month
+        every { LocalDate.now(ZoneId.of("Asia/Tokyo")) } returns aprilDate.minusDays(2) // Set today to 2026-04-28 to cross month
 
         every { scheduleDataSource.fetchMonthlyData(YearMonth.of(2026, 4)) } returns aprilData
         every { scheduleDataSource.fetchMonthlyData(YearMonth.of(2026, 5)) } returns mayData


### PR DESCRIPTION
### Pre-merge Checklist

- [x] Assignees are set.
- [x] Labels are set.
- [x] Milestone is set.

---

## Related issues

* #12

### Cause of bug

* The method `LocalDate.now()` does not set any time zone, thus the default time zone "UTC" is applied.

### What's fixed

* Applied the time zone of "Asia/Tokyo".

### Unit Test

* Passed all unit tests.

### Notes

* 
